### PR TITLE
Fix river generation min flux and city rendering order

### DIFF
--- a/archipelago_generator/render.py
+++ b/archipelago_generator/render.py
@@ -33,15 +33,15 @@ def render_archipelago(arch: Archipelago) -> None:
         for x in range(arch.width):
             ch: str
             rgb: tuple[int, int, int]
-            if arch.road_map[y, x]:
+            if (y, x) in cities:
+                ch, rgb = "@", (230, 180, 0)
+            elif arch.road_map[y, x]:
                 ch, rgb = ":", (180, 100, 50)
             elif arch.river_map[y, x] > 0:
                 if arch.river_width[y, x] > 2:
                     ch, rgb = "≡", (0, 100, 255)
                 else:
                     ch, rgb = "=", (80, 180, 255)
-            elif (y, x) in cities:
-                ch, rgb = "@", (230, 180, 0)
             else:
                 biome = grid[y, x]
                 ch, rgb = BIOME_GLYPHS.get(biome, ("?", (255, 255, 255)))

--- a/archipelago_generator/rivers.py
+++ b/archipelago_generator/rivers.py
@@ -57,7 +57,7 @@ def compute_water_flux(elevation: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
 
 
 def trace_rivers(
-    water_flux: np.ndarray, downslope: np.ndarray, elevation: np.ndarray, *, min_flux: float = 20.0
+    water_flux: np.ndarray, downslope: np.ndarray, elevation: np.ndarray, *, min_flux: float = 3.0
 ) -> tuple[np.ndarray, np.ndarray]:
     """Trace river paths following downslope until reaching sea level."""
 


### PR DESCRIPTION
## Summary
- reduce minimum water flux threshold so rivers generate
- render city glyphs on top of roads

## Testing
- `PYTHONPATH=$PWD pytest -q`
- `python archipelago_generator/examples/demo.py --width 80 --height 40 --seed 1 > /tmp/demo.txt && head -n 5 /tmp/demo.txt`


------
https://chatgpt.com/codex/tasks/task_e_686e4c7db56c83279412bac9ef6e862b