### PR TITLE
Add sea level parameter to river utilities

### DIFF
--- a/archipelago_generator/generator.py
+++ b/archipelago_generator/generator.py
@@ -71,9 +71,14 @@ def generate_archipelago(**kwargs) -> Archipelago:
 
     # Rasterize elevation for river and city generation
     elev_grid = rasterize(cells, elevation, params.width, params.height)
-    river_map, river_width = compute_rivers(elev_grid)
-    cities = place_cities(river_map, elev_grid, n_cities=params.num_cities)
-    road_map = build_roads(cities, elev_grid)
+    river_map, river_width = compute_rivers(elev_grid, sea_level=params.sea_level)
+    cities = place_cities(
+        river_map,
+        elev_grid,
+        n_cities=params.num_cities,
+        sea_level=params.sea_level,
+    )
+    road_map = build_roads(cities, elev_grid, sea_level=params.sea_level)
 
     return Archipelago(
         width=params.width,

--- a/tests/test_archipelago_generator.py
+++ b/tests/test_archipelago_generator.py
@@ -2,7 +2,7 @@ import numpy as np
 from archipelago_generator import generate_archipelago
 from archipelago_generator import render_archipelago
 from archipelago_generator.rasterizer import rasterize
-from archipelago_generator.rivers import SEA_LEVEL
+from archipelago_generator.generator import ArchipelagoParams
 
 
 def test_deterministic():
@@ -44,9 +44,10 @@ def test_render_legend(capsys):
 
 
 def test_roads_on_land():
-    arch = generate_archipelago(width=60, height=60, seed=4)
+    sea_level = ArchipelagoParams.sea_level
+    arch = generate_archipelago(width=60, height=60, seed=4, sea_level=sea_level)
     elev_grid = rasterize(arch.cells, arch.elevation, arch.width, arch.height)
     for y in range(arch.height):
         for x in range(arch.width):
             if arch.road_map[y, x]:
-                assert elev_grid[y, x] >= SEA_LEVEL
+                assert elev_grid[y, x] >= sea_level


### PR DESCRIPTION
## Summary
- allow custom sea level in river generation utilities
- pass sea level from generator to river, city, and road functions
- update tests to use ArchipelagoParams.sea_level when checking road placement

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fd847376483278096cba171967907