### PR TITLE
Add Perlin noise distortion to roads

### DIFF
--- a/archipelago_generator/climate.py
+++ b/archipelago_generator/climate.py
@@ -6,8 +6,17 @@ import numpy as np
 from perlin_noise import PerlinNoise
 
 
-def compute_temperature(cells, height: float) -> np.ndarray:
-    noise = PerlinNoise(seed=42)
+def compute_temperature(
+    cells,
+    height: float,
+    rng: np.random.Generator | None = None,
+) -> np.ndarray:
+    """Generate latitudinal temperature gradient with subtle noise."""
+
+    if rng is None:
+        rng = np.random.default_rng(0)
+
+    noise = PerlinNoise(seed=int(rng.integers(0, 10_000)))
     temp = np.zeros(len(cells))
     for i, poly in enumerate(cells):
         y = poly.centroid.y / height

--- a/archipelago_generator/generator.py
+++ b/archipelago_generator/generator.py
@@ -61,7 +61,7 @@ def generate_archipelago(**kwargs) -> Archipelago:
     elevation = assign_elevation(cells, params.width, params.height, rng)
     land_mask = elevation > params.sea_level
     land = land_mask.astype(bool)
-    temperature = compute_temperature(cells, params.height)
+    temperature = compute_temperature(cells, params.height, rng)
     rainfall = compute_rainfall(cells, rng)
     moisture = compute_moisture(rainfall)
     biome = classify_biomes(land, temperature, moisture)
@@ -77,8 +77,14 @@ def generate_archipelago(**kwargs) -> Archipelago:
         elev_grid,
         n_cities=params.num_cities,
         sea_level=params.sea_level,
+        rng=rng,
     )
-    road_map = build_roads(cities, elev_grid, sea_level=params.sea_level)
+    road_map = build_roads(
+        cities,
+        elev_grid,
+        sea_level=params.sea_level,
+        seed=int(rng.integers(0, 1_000_000)),
+    )
 
     return Archipelago(
         width=params.width,


### PR DESCRIPTION
## Summary
- distort roads with Perlin noise for less straight paths
- propagate RNG seed into road generation
- pass CLI seed through temperature and city placement so all modules share the same RNG

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68711b1665808327862b611858b2865a