### PR TITLE
Add polyline rasterization

### DIFF
--- a/archipelago_generator/__init__.py
+++ b/archipelago_generator/__init__.py
@@ -2,5 +2,6 @@
 
 from .generator import generate_archipelago
 from .render import render_archipelago
+from .rasterizer import Rasterizer
 
-__all__ = ["generate_archipelago", "render_archipelago"]
+__all__ = ["generate_archipelago", "render_archipelago", "Rasterizer"]

--- a/archipelago_generator/examples/demo.py
+++ b/archipelago_generator/examples/demo.py
@@ -17,8 +17,18 @@ def main() -> None:
     parser.add_argument("--height", type=int, default=200)
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--legend", action="store_true", help="show biome legend")
+    parser.add_argument("--river-width", type=int, default=1)
+    parser.add_argument("--road-width", type=int, default=1)
+    parser.add_argument("--jitter", action="store_true", help="enable jitter")
     args = parser.parse_args()
-    arch = generate_archipelago(width=args.width, height=args.height, seed=args.seed)
+    arch = generate_archipelago(
+        width=args.width,
+        height=args.height,
+        seed=args.seed,
+        river_width_tiles=args.river_width,
+        road_width_tiles=args.road_width,
+        jitter=args.jitter,
+    )
     print(f"Generated archipelago with {len(arch.cells)} cells")
     render_archipelago(arch, show_legend=args.legend)
 

--- a/archipelago_generator/generator.py
+++ b/archipelago_generator/generator.py
@@ -18,7 +18,7 @@ from .rivers import compute_rivers
 from .cities import place_cities
 from .roads import build_roads
 from .borders import unite_regions, compute_borders
-from .rasterizer import rasterize
+from .rasterizer import rasterize, Rasterizer
 from .utils import seeded_rng
 
 
@@ -31,6 +31,9 @@ class ArchipelagoParams:
     relax_iterations: int = 2
     sea_level: float = 0.5
     num_cities: int = 3
+    river_width_tiles: int = 1
+    road_width_tiles: int = 1
+    jitter: bool = False
 
 
 @dataclass
@@ -46,7 +49,9 @@ class Archipelago:
     biome: np.ndarray
     river_map: np.ndarray
     river_width: np.ndarray
+    river_lines: list[list[tuple[float, float]]]
     road_map: np.ndarray
+    road_lines: list[list[tuple[float, float]]]
     cities: list[tuple[int, int]]
     borders: list[LineString]
     regions: np.ndarray
@@ -73,7 +78,17 @@ def generate_archipelago(**kwargs) -> Archipelago:
 
     # Rasterize elevation for river and city generation
     elev_grid = rasterize(cells, elevation, params.width, params.height)
-    river_map, river_width = compute_rivers(elev_grid, sea_level=params.sea_level)
+    river_map, river_width, river_lines = compute_rivers(
+        elev_grid, sea_level=params.sea_level
+    )
+    rasterizer = Rasterizer(params.width, params.height, seed=int(rng.integers(0, 1_000_000)))
+    river_jitter = {'freq': 0.1, 'strength': 0.5} if params.jitter else None
+    river_map = rasterizer.rasterize_rivers(
+        river_lines,
+        width_tiles=params.river_width_tiles,
+        density=1.0,
+        jitter=river_jitter,
+    )
     cities = place_cities(
         river_map,
         elev_grid,
@@ -81,11 +96,18 @@ def generate_archipelago(**kwargs) -> Archipelago:
         sea_level=params.sea_level,
         rng=rng,
     )
-    road_map = build_roads(
+    road_map, road_lines = build_roads(
         cities,
         elev_grid,
         sea_level=params.sea_level,
         seed=int(rng.integers(0, 1_000_000)),
+    )
+    road_jitter = {'freq': 0.2, 'strength': 0.3} if params.jitter else None
+    road_map = rasterizer.rasterize_roads(
+        road_lines,
+        width_tiles=params.road_width_tiles,
+        density=1.0,
+        jitter=road_jitter,
     )
 
     return Archipelago(
@@ -100,7 +122,9 @@ def generate_archipelago(**kwargs) -> Archipelago:
         biome=biome,
         river_map=river_map,
         river_width=river_width,
+        river_lines=river_lines,
         road_map=road_map,
+        road_lines=road_lines,
         cities=cities,
         borders=borders,
         regions=regions,

--- a/archipelago_generator/rasterizer.py
+++ b/archipelago_generator/rasterizer.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import List, Tuple, Optional, Dict
 
 import numpy as np
 from shapely.geometry import Polygon, Point
 from shapely.strtree import STRtree
 from shapely.prepared import prep
+from perlin_noise import PerlinNoise
 
 
 def rasterize(cells: List[Polygon], values: np.ndarray, width: int, height: int) -> np.ndarray:
@@ -26,4 +27,112 @@ def rasterize(cells: List[Polygon], values: np.ndarray, width: int, height: int)
                     grid[y, x] = values[idx]
                     break
     return grid
+
+
+class Rasterizer:
+    """Utility to rasterize polylines into boolean masks."""
+
+    def __init__(self, width: int, height: int, seed: int | None = None) -> None:
+        self.width = width
+        self.height = height
+        self.noise = PerlinNoise(octaves=1, seed=seed or 0)
+
+    def jitter_polyline(
+        self,
+        polyline: List[Tuple[float, float]],
+        freq: float,
+        strength: float,
+    ) -> List[Tuple[float, float]]:
+        """Displace vertices along the normal by Perlin noise."""
+
+        if len(polyline) < 2:
+            return polyline
+
+        jit: List[Tuple[float, float]] = [polyline[0]]
+        for i in range(1, len(polyline) - 1):
+            x, y = polyline[i]
+            x0, y0 = polyline[i - 1]
+            x1, y1 = polyline[i + 1]
+            dx = x1 - x0
+            dy = y1 - y0
+            nx, ny = -dy, dx
+            norm = (nx ** 2 + ny ** 2) ** 0.5
+            if norm != 0:
+                nx /= norm
+                ny /= norm
+                u, v = x / freq, y / freq
+                offset = (self.noise([u, v]) - 0.5) * 2 * strength
+                x += nx * offset
+                y += ny * offset
+            jit.append((x, y))
+        jit.append(polyline[-1])
+        return jit
+
+    def rasterize_polyline(
+        self,
+        polyline: List[Tuple[float, float]],
+        brush_radius: float,
+        sampling_density: float,
+    ) -> np.ndarray:
+        """Rasterize a single polyline to a boolean mask."""
+
+        mask = np.zeros((self.height, self.width), dtype=bool)
+        if len(polyline) < 2:
+            return mask
+
+        for p0, p1 in zip(polyline[:-1], polyline[1:]):
+            x0, y0 = p0
+            x1, y1 = p1
+            seg_len = ((x1 - x0) ** 2 + (y1 - y0) ** 2) ** 0.5
+            samples = max(int(np.ceil(seg_len * sampling_density)), 1)
+            for i in range(samples + 1):
+                t = i / samples
+                x = x0 + (x1 - x0) * t
+                y = y0 + (y1 - y0) * t
+                xmin = int(max(0, np.floor(x - brush_radius)))
+                xmax = int(min(self.width - 1, np.ceil(x + brush_radius)))
+                ymin = int(max(0, np.floor(y - brush_radius)))
+                ymax = int(min(self.height - 1, np.ceil(y + brush_radius)))
+                for yy in range(ymin, ymax + 1):
+                    for xx in range(xmin, xmax + 1):
+                        if (xx - x) ** 2 + (yy - y) ** 2 <= brush_radius ** 2:
+                            mask[yy, xx] = True
+        return mask
+
+    def _combine_masks(self, masks: List[np.ndarray]) -> np.ndarray:
+        combined = np.zeros((self.height, self.width), dtype=bool)
+        for m in masks:
+            combined |= m
+        return combined
+
+    def rasterize_rivers(
+        self,
+        rivers: List[List[Tuple[float, float]]],
+        width_tiles: int = 1,
+        density: float = 1.0,
+        jitter: Optional[Dict[str, float]] = None,
+    ) -> np.ndarray:
+        masks = []
+        radius = max(0.5, width_tiles / 2)
+        for line in rivers:
+            if jitter:
+                line = self.jitter_polyline(line, jitter.get("freq", 1.0), jitter.get("strength", 1.0))
+            masks.append(self.rasterize_polyline(line, radius, density))
+        return self._combine_masks(masks)
+
+    def rasterize_roads(
+        self,
+        roads: List[List[Tuple[float, float]]],
+        width_tiles: int = 1,
+        density: float = 1.0,
+        jitter: Optional[Dict[str, float]] = None,
+    ) -> np.ndarray:
+        masks = []
+        radius = max(0.5, width_tiles / 2)
+        for line in roads:
+            if jitter:
+                line = self.jitter_polyline(line, jitter.get("freq", 1.0), jitter.get("strength", 1.0))
+            masks.append(self.rasterize_polyline(line, radius, density))
+        return self._combine_masks(masks)
+
 

--- a/archipelago_generator/roads.py
+++ b/archipelago_generator/roads.py
@@ -80,7 +80,7 @@ def build_roads(
     noise_amplitude: float = 1.0,
     noise_frequency: float = 0.15,
     seed: int = 0,
-) -> np.ndarray:
+) -> tuple[np.ndarray, List[List[Tuple[float, float]]]]:
     """Connect consecutive cities using A* to create roads.
 
     The resulting paths are lightly distorted using 1D Perlin noise to avoid
@@ -89,8 +89,9 @@ def build_roads(
 
     height, width = elevation.shape
     road = np.zeros((height, width), dtype=bool)
+    lines: List[List[Tuple[float, float]]] = []
     if len(cities) < 2:
-        return road
+        return road, lines
 
     cost = 1.0 + elevation * 3.0
     cost[elevation < sea_level] = 1e6
@@ -108,6 +109,7 @@ def build_roads(
             amplitude=noise_amplitude,
             frequency=noise_frequency,
         )
+        lines.append([(pt[0], pt[1]) for pt in line.coords])
 
         length = line.length
         d = 0.0
@@ -118,4 +120,4 @@ def build_roads(
             if 0 <= y < height and 0 <= x < width and elevation[y, x] >= sea_level:
                 road[y, x] = True
             d += 1.0
-    return road
+    return road, lines

--- a/tests/test_rasterizer.py
+++ b/tests/test_rasterizer.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from archipelago_generator.rasterizer import Rasterizer
+
+
+def test_rasterize_line():
+    r = Rasterizer(10, 5, seed=1)
+    line = [(0, 2), (9, 2)]
+    mask = r.rasterize_polyline(line, brush_radius=0.5, sampling_density=1.0)
+    assert mask.shape == (5, 10)
+    assert mask[2].all()
+
+
+def test_jitter_determinism():
+    r1 = Rasterizer(10, 10, seed=42)
+    r2 = Rasterizer(10, 10, seed=42)
+    line = [(0.0, 0.0), (5.0, 5.0), (9.0, 9.0)]
+    j1 = r1.jitter_polyline(line, freq=1.0, strength=1.0)
+    j2 = r2.jitter_polyline(line, freq=1.0, strength=1.0)
+    assert np.allclose(j1, j2)
+


### PR DESCRIPTION
## Summary
- expand rasterizer with Rasterizer class for jittered polyline masks
- return river and road polylines from generation helpers
- use Rasterizer inside generator and expose options for width/jitter
- expose Rasterizer in package init
- extend demo CLI with width/jitter options
- add rasterizer unit tests

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687184dd3638832791d143416dcf7f3a